### PR TITLE
Fix overflow in shutdown

### DIFF
--- a/src/SimpleCqrs.Core/SimpleCqrsRuntime.cs
+++ b/src/SimpleCqrs.Core/SimpleCqrsRuntime.cs
@@ -14,7 +14,7 @@ namespace SimpleCqrs
         {
             var serviceLocator = GetServiceLocator();
 
-            serviceLocator.Register<IServiceLocator>(serviceLocator);
+            serviceLocator.Register<IServiceLocator>(() => serviceLocator);
             serviceLocator.Register(BuildTheTypeCatalog(serviceLocator));
             serviceLocator.Register(GetCommandBus(serviceLocator));
             serviceLocator.Register(GetEventBus(serviceLocator));


### PR DESCRIPTION
Just registered the service locator with a factory method, otherwise the container would get caught in a stack overflow on dispose.
