### PR TITLE
CommandHandlerInvoker to throw "real" exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ bin
 *.user
 *.gpState
 TestResults
+[Bb]inaries

--- a/src/SimpleCqrs/Commanding/LocalCommandBus.cs
+++ b/src/SimpleCqrs/Commanding/LocalCommandBus.cs
@@ -68,7 +68,15 @@ namespace SimpleCqrs.Commanding
             {
                 var handleMethod = GetTheHandleMethod();
                 var commandHandler = CreateTheCommandHandler();
-                handleMethod.Invoke(commandHandler, new object[] {handlingContext});
+
+                try
+                {
+                    handleMethod.Invoke(commandHandler, new object[] { handlingContext });
+                }
+                catch(TargetInvocationException ex)
+                {
+                    throw ex.InnerException;
+                }
             }
 
             private ICommandHandlingContext<ICommand> CreateTheCommandHandlingContext(ICommand command)

--- a/src/Tests/SimpleCqrs.Tests/CustomAsserts.cs
+++ b/src/Tests/SimpleCqrs.Tests/CustomAsserts.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SimpleCqrs.Core.Tests
+{
+    public static class CustomAsserts
+    {
+        [DebuggerStepThrough()]
+        public static T Throws<T>(Action action) where T : Exception
+        {
+            try
+            {
+                action.Invoke();
+            }
+            catch (T ex)
+            {
+                return ex;
+            }
+            catch (Exception ex)
+            {
+                throw new AssertFailedException(
+                    string.Format("Expected exception was not thrown! Got other exception: '{0}'.", ex.GetType())
+                    ,ex);
+            }
+
+            throw new AssertFailedException("Expected exception was not thrown! None was thrown.");
+        }
+    }
+}

--- a/src/Tests/SimpleCqrs.Tests/SimpleCqrs.Tests.csproj
+++ b/src/Tests/SimpleCqrs.Tests/SimpleCqrs.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Events\DirectEventBusTests.cs" />
     <Compile Include="Domain\DomainRepositoryTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="CustomAsserts.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\SimpleCqrs\SimpleCqrs.csproj">


### PR DESCRIPTION
We throwed an exception in a commandhandler and since it is invoked via reflection, the "DomainException" was nested in the inner exception of the TargetInvocationException. That is of no interest, hence why not rethrow the "real" exception. Perhaps a performance loss. Anyway. There's of course the situation of someone generating a TargetInvocationException in the handler, and then the "Real" exception would lie two levels down, but I guess recursion in this situation might be overkill. You decide.

[Fixed]: When commandhandler generates specific exception, it should be rethrown, not reflection exception.

//Daniel
